### PR TITLE
Replace `KEYS` by `SCAN`

### DIFF
--- a/tests/Drivers/MultiDriverTest.php
+++ b/tests/Drivers/MultiDriverTest.php
@@ -148,7 +148,7 @@ class MultiDriverTest extends TestCase
         $this->testRedisClient->set($keys[2], 3);
 
         $driver = new MultiDriver($this->testRedisClient);
-        $result = $driver->key('testing:*')->keys();
+        $result = $driver->key('testing:*')->countPerScan(1)->keys();
 
         sort($expected);
         sort($result);
@@ -223,7 +223,7 @@ class MultiDriverTest extends TestCase
     /**
      * @test
      */
-    public function it_should_get_zero()
+    public function it_should_get_zero_count()
     {
         $keys = [];
         $expected = 0;
@@ -236,7 +236,7 @@ class MultiDriverTest extends TestCase
     /**
      * @test
      */
-    public function it_should_get_one()
+    public function it_should_get_one_count()
     {
         $key = $this->assembleKey('example');
         $expected = 1;
@@ -246,65 +246,6 @@ class MultiDriverTest extends TestCase
         $driver = new MultiDriver($this->testRedisClient);
         $result = $driver->key($key)->count();
         $this->assertEquals($expected, $result);
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_find_keys_by_scan()
-    {
-        $keyPattern = $this->assembleKey('*');
-        $key1 = $this->assembleKey('abc');
-        $key2 = $this->assembleKey('def');
-        $key3 = $this->assembleKey('ghi');
-        $keys = [
-            $key1,
-            $key2,
-            $key3,
-        ];
-        $expected = $keys;
-        $this->testRedisClient->set($keys[0], 1);
-        $this->testRedisClient->set($keys[1], 2);
-        $this->testRedisClient->set($keys[2], 3);
-
-        $driver = new MultiDriver($this->testRedisClient);
-        $cursor = '0';
-        $actual = [];
-        do {
-            list($cursor, $results) = $driver->key($keyPattern)->scan($cursor, 1);
-            foreach ($results as $key) {
-                $actual[] = $key;
-            }
-        } while ($cursor !== '0');
-        sort($expected);
-        sort($actual);
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     * @test
-     */
-    public function it_should_scan_all_keys()
-    {
-        $keyPattern = $this->assembleKey('*');
-        $key1 = $this->assembleKey('abc');
-        $key2 = $this->assembleKey('def');
-        $key3 = $this->assembleKey('ghi');
-        $keys = [
-            $key1,
-            $key2,
-            $key3,
-        ];
-        $expected = $keys;
-        $this->testRedisClient->set($keys[0], 1);
-        $this->testRedisClient->set($keys[1], 2);
-        $this->testRedisClient->set($keys[2], 3);
-
-        $driver = new MultiDriver($this->testRedisClient);
-        $actual = $driver->key($keyPattern)->scanAll(1);
-        sort($expected);
-        sort($actual);
-        $this->assertEquals($expected, $actual);
     }
 
     /**
@@ -323,7 +264,7 @@ class MultiDriverTest extends TestCase
         $this->testRedisClient->set($keys[1], 2);
         $expected = [];
         $driver = new MultiDriver($this->testRedisClient);
-        $actual = $driver->key($keyPattern)->scanAll(1);
+        $actual = $driver->key($keyPattern)->countPerScan(1)->get();
         $this->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
因考量 `KEYS` 指令會造成 block 的問題

multi driver 搜尋 key 的實作方法都改為 `SCAN`

1. 調整 `MultiDriver` 對外接口
2. 調整測試
3. 移除 deprecated method