### PR TITLE
調整 multi driver 使用介面

### DIFF
--- a/src/Drivers/MultiDriver.php
+++ b/src/Drivers/MultiDriver.php
@@ -2,6 +2,8 @@
 
 namespace Goez\RedisDataHelper\Drivers;
 
+use InvalidArgumentException;
+
 class MultiDriver extends AbstractDriver
 {
     /**
@@ -36,18 +38,18 @@ class MultiDriver extends AbstractDriver
     }
 
     /**
-     * 取得設定的 countPerScan，不存在則用 ({key 總數量} / 5)
+     * 取得設定的 countPerScan，不存在則拋出 exception
+     * 因 predis library replication mode 不支援 `dbsize` 指令，無法動態計算
+     * 避免忽略此參數，因此不給預設值，使用時一定要給 countPerScan 參數
      *
      * @return int
+     * @throws InvalidArgumentException
      */
     private function getCountPerScan()
     {
         if (!$this->countPerScan) {
-            // default value
-            $totalKeys = $this->client->dbsize();
-            return ceil($totalKeys / 6);
+            throw new InvalidArgumentException('Parameter countPerScan is required');
         }
-
         return $this->countPerScan;
     }
 

--- a/tests/Drivers/MultiDriverTest.php
+++ b/tests/Drivers/MultiDriverTest.php
@@ -21,7 +21,7 @@ class MultiDriverTest extends TestCase
     public function it_should_delete_nothing()
     {
         $driver = new MultiDriver($this->testRedisClient);
-        $count = $driver->key('nothing')->delete();
+        $count = $driver->key('nothing')->countPerScan(1)->delete();
         $this->assertEquals(0, $count);
     }
 
@@ -44,7 +44,7 @@ class MultiDriverTest extends TestCase
         $this->assertCount(3, $result);
 
         $driver = new MultiDriver($this->testRedisClient);
-        $count = $driver->key($keyPattern)->delete();
+        $count = $driver->key($keyPattern)->countPerScan(1)->delete();
         $this->assertEquals(3, $count);
     }
 
@@ -65,7 +65,7 @@ class MultiDriverTest extends TestCase
         $this->testRedisClient->set($keys[2], 3);
 
         $driver = new MultiDriver($this->testRedisClient);
-        $actual = $driver->key($keyPattern)->get();
+        $actual = $driver->key($keyPattern)->countPerScan(1)->get();
         sort($expected);
         sort($actual);
         $this->assertEquals($expected, $actual);
@@ -87,7 +87,7 @@ class MultiDriverTest extends TestCase
         $this->testRedisClient->set($keys[2], 3);
 
         $driver = new MultiDriver($this->testRedisClient);
-        $result = $driver->key($keys)->get();
+        $result = $driver->key($keys)->countPerScan(1)->get();
         $this->assertEquals($expected, $result);
     }
 
@@ -98,7 +98,7 @@ class MultiDriverTest extends TestCase
     {
         $expected = [];
         $driver = new MultiDriver($this->testRedisClient);
-        $result = $driver->get();
+        $result = $driver->countPerScan(1)->get();
         $this->assertEquals($expected, $result);
     }
 
@@ -109,7 +109,7 @@ class MultiDriverTest extends TestCase
     {
         $expected = [];
         $driver = new MultiDriver($this->testRedisClient);
-        $result = $driver->key('example:*')->get();
+        $result = $driver->key('example:*')->countPerScan(1)->get();
         $this->assertEquals($expected, $result);
     }
 
@@ -124,7 +124,7 @@ class MultiDriverTest extends TestCase
             $this->assembleKey('abc'),
             $this->assembleKey('def'),
             $this->assembleKey('ghi'),
-        ])->get();
+        ])->countPerScan(1)->get();
         $this->assertEquals($expected, $result);
     }
 
@@ -175,7 +175,7 @@ class MultiDriverTest extends TestCase
         $this->testRedisClient->set($keys[2], 3);
 
         $driver = new MultiDriver($this->testRedisClient);
-        $result = $driver->key($keys)->withKey()->get();
+        $result = $driver->key($keys)->countPerScan(1)->withKey()->get();
         $this->assertEquals($expected, $result);
     }
 
@@ -199,7 +199,7 @@ class MultiDriverTest extends TestCase
         $this->testRedisClient->set($keys[2], 3);
 
         $driver = new MultiDriver($this->testRedisClient);
-        $result = $driver->key('testing:*')->withKey()->get();
+        $result = $driver->key('testing:*')->countPerScan(1)->withKey()->get();
         $this->assertEquals($expected, $result);
     }
 
@@ -216,7 +216,7 @@ class MultiDriverTest extends TestCase
         $expected = 3;
 
         $driver = new MultiDriver($this->testRedisClient);
-        $result = $driver->key($keys)->count();
+        $result = $driver->key($keys)->countPerScan(1)->count();
         $this->assertEquals($expected, $result);
     }
 
@@ -229,7 +229,7 @@ class MultiDriverTest extends TestCase
         $expected = 0;
 
         $driver = new MultiDriver($this->testRedisClient);
-        $result = $driver->key($keys)->count();
+        $result = $driver->key($keys)->countPerScan(1)->count();
         $this->assertEquals($expected, $result);
     }
 
@@ -244,7 +244,7 @@ class MultiDriverTest extends TestCase
         $this->testRedisClient->set($key, 1);
 
         $driver = new MultiDriver($this->testRedisClient);
-        $result = $driver->key($key)->count();
+        $result = $driver->key($key)->countPerScan(1)->count();
         $this->assertEquals($expected, $result);
     }
 


### PR DESCRIPTION
predis 的 replication mode 無法使用 `dbsize` 指令

因此無法在 library 中動態計算

因此不設預設值，並且在沒有給值的情況下拋出 exception

調整後使用時都要加上 `countPerScan()` 方法