### PR TITLE
新增使用 scan 進行全掃開關

### DIFF
--- a/src/Drivers/MultiDriver.php
+++ b/src/Drivers/MultiDriver.php
@@ -143,7 +143,7 @@ class MultiDriver extends AbstractDriver
         ];
 
         do {
-            list($cursor, $result) = $this->client->scan($cursor, $options);
+            [$cursor, $result] = $this->client->scan($cursor, $options);
             $bufferArray[] = $result;
         } while ($cursor !== '0');
 

--- a/tests/Drivers/MultiDriverTest.php
+++ b/tests/Drivers/MultiDriverTest.php
@@ -247,4 +247,49 @@ class MultiDriverTest extends TestCase
         $result = $driver->key($key)->count();
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @test
+     */
+    public function it_should_get_keys_count_by_scan()
+    {
+        $expected = 3;
+        $keyPattern = $this->assembleKey('a-*');
+        $keys = [
+            $this->assembleKey('a-1'),
+            $this->assembleKey('a-2'),
+            $this->assembleKey('a-3'),
+            $this->assembleKey('b-4'),
+        ];
+        $this->testRedisClient->set($keys[0], 1);
+        $this->testRedisClient->set($keys[1], 2);
+        $this->testRedisClient->set($keys[2], 3);
+
+        $driver = new MultiDriver($this->testRedisClient);
+        $result = $driver->key($keyPattern)->useScan()->count();
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_get_multiple_value_with_key_by_scan()
+    {
+        $keyPattern = $this->assembleKey('*');
+        $keys = [
+            $this->assembleKey('abc'),
+            $this->assembleKey('def'),
+            $this->assembleKey('ghi'),
+        ];
+        $expected = [1, 2, 3,];
+        $this->testRedisClient->set($keys[0], 1);
+        $this->testRedisClient->set($keys[1], 2);
+        $this->testRedisClient->set($keys[2], 3);
+
+        $driver = new MultiDriver($this->testRedisClient);
+        $actual = $driver->key($keyPattern)->useScan(1)->get();
+        sort($expected);
+        sort($actual);
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
本次修改:

1. 新增 useScan 方法，可用來開啟使用 scan 來替代 keys 掃描。
2. 新增相關測試。

備註:

原本有在此 pr #4 將所有的 keys 替代成 scan，但是考慮到會影響到現階段已使用的應用，因此在 #6 又 revert 回去。

而此 pr 是新增一個 scan 開關，來決定全掃的方法，預設是 keys，只有在使用 useScan 時，才會轉成用 scan，這樣就不會影響到正在使用的程式碼。
